### PR TITLE
Mudando guard e rotas de canActivate para canActivateChild

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,7 +36,7 @@ const routes: Routes = [
   {path:'login', component:LoginComponent},   
 
   {
-    path:'', component:MasterDefaultComponent, canActivate:[usuarioAutenticadoGuard],
+    path:'', component:MasterDefaultComponent, canActivateChild:[usuarioAutenticadoGuard],
     children: [
       {path:'', redirectTo:'home', pathMatch:'full'},
       {path:'home', component:HomeComponent, },

--- a/src/app/services/guards/usuario-autenticado.guard.ts
+++ b/src/app/services/guards/usuario-autenticado.guard.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { CanActivateChildFn, Router } from '@angular/router';
 import { AutenticacaoService } from '../autenticacoes/autenticacao.service';
 
-export const usuarioAutenticadoGuard: CanActivateFn = (route, state) => {
+export const usuarioAutenticadoGuard: CanActivateChildFn = (route, state) => {
   return inject(AutenticacaoService).isAutenticado ? true : inject(Router).createUrlTree(['/login']);
 };


### PR DESCRIPTION
Mudando o guarda de canActivate para canActivateChild para que as rotas filhas possa ser guardadas apropriadamente.